### PR TITLE
Fix to not depend on closure environment

### DIFF
--- a/polyfill.js
+++ b/polyfill.js
@@ -1,8 +1,8 @@
-var global = Function('return this;')();
-
-if (typeof System !== 'object') {
-	global.System = {};
-}
-if (!System.global) {
-	System.global = global;
-}
+(function (global) {
+	if (typeof System !== 'object') {
+		global.System = {};
+	}
+	if (!System.global) {
+		System.global = global;
+	}
+})(typeof this === 'object' ? this : Function('return this')())


### PR DESCRIPTION
The added closure keeps from introducing `global` as a global variable in browsers and shells. Which makes this more portable.

Also, testing that `this` is an object works better when loaded from a script context, as creating a function is unnecessary unless in a module context. Because of that, this is CSP safe unless the global scope is in strict mode already (which is bad practice from the start).
