### PR TITLE
update link to npm-package in README.md (current link is a deprecated package)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [global](https://www.npmjs.com/package/system.global)
+# [global](https://www.npmjs.com/package/globalthis)
 ECMAScript Proposal, specs, and reference implementation for `globalThis`
 
 Spec drafted by [@ljharb](https://github.com/ljharb).


### PR DESCRIPTION
verified clicking the new link in README.md leads to correct npm-package:

![image](https://user-images.githubusercontent.com/280571/46251281-d85ea100-c478-11e8-9bd1-822334314cce.png)
